### PR TITLE
Add exception handler to the scan action.

### DIFF
--- a/bt_helper.py
+++ b/bt_helper.py
@@ -73,7 +73,16 @@ class BtDbusManager:
                 arg0 = "org.bluez.Device1",
                 path_keyword = "path")
         for adapter in self._get_objects_by_iface(ADAPTER_IFACE):
-            dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+            try:
+                dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+            except Exception as exc:
+                if exc.get_dbus_name() == 'org.bluez.Error.InProgress':
+                    logging.warning('Scan already in progress, restart it now')
+                    dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
+                    dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+                else:
+                    logging.error('Unable to start scanning - {}'
+                                  .format(exc.get_dbus_message())
         mainloop = GObject.MainLoop()
         mainloop.run()
 

--- a/bt_helper.py
+++ b/bt_helper.py
@@ -74,15 +74,11 @@ class BtDbusManager:
                 path_keyword = "path")
         for adapter in self._get_objects_by_iface(ADAPTER_IFACE):
             try:
+                dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
                 dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
             except Exception as exc:
-                if exc.get_dbus_name() == 'org.bluez.Error.InProgress':
-                    logging.warning('Scan already in progress, restart it now')
-                    dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
-                    dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
-                else:
-                    logging.error('Unable to start scanning - {}'
-                                  .format(exc.get_dbus_message())
+                logging.error('Unable to start scanning - {}'
+                              .format(exc.get_dbus_message())
         mainloop = GObject.MainLoop()
         mainloop.run()
 


### PR DESCRIPTION
Ask the adapter to stop discovery first and then start it, so every exception can be caught by the try statement.
