### PR TITLE
Add exception handler to scan action.

### DIFF
--- a/bt_helper.py
+++ b/bt_helper.py
@@ -73,7 +73,16 @@ class BtDbusManager:
                 arg0 = "org.bluez.Device1",
                 path_keyword = "path")
         for adapter in self._get_objects_by_iface(ADAPTER_IFACE):
-            dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+            try:
+                dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+            except Exception as exc:
+                if exc.get_dbus_name() == 'org.bluez.Error.InProgress':
+                    logging.warning('Scan already in progress, restart it now')
+                    dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
+                    dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+                else:
+                    logging.error('Unable to start scanning - {}'
+                                  .format(exc.get_dbus_message())
         mainloop = GObject.MainLoop()
         mainloop.run()
 


### PR DESCRIPTION
Ask the interface to restart discovery if it's already in scanning mode.

Note: This might not be a very good solution, it might also fail to stop / start discovery in that if statement, and making runaway exceptions. Another solution maybe is to reset it at the very beginning.
