### PR TITLE
Add exception handler to scan action.

### DIFF
--- a/bt_helper.py
+++ b/bt_helper.py
@@ -81,15 +81,10 @@ class BtDbusManager:
                 path_keyword = "path")
         for adapter in self._get_objects_by_iface(ADAPTER_IFACE):
             try:
-                dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
-            except Exception as exc:
-                if exc.get_dbus_name() == 'org.bluez.Error.InProgress':
-                    logging.warning('Scan already in progress, restart it now')
-                    dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
-                    dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
-                else:
-                    logging.error('Unable to start scanning - {}'
-                                  .format(exc.get_dbus_message())
+                dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
+            except dbus.exceptions.DBusException as exc:
+                pass
+            dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
         GObject.timeout_add(10000, self._scan_timeout)
         self._main_loop.run()
 

--- a/bt_helper.py
+++ b/bt_helper.py
@@ -82,7 +82,7 @@ class BtDbusManager:
         for adapter in self._get_objects_by_iface(ADAPTER_IFACE):
             try:
                 dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
-            except dbus.exceptions.DBusException as exc:
+            except dbus.exceptions.DBusException:
                 pass
             dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
         GObject.timeout_add(10000, self._scan_timeout)

--- a/bt_helper.py
+++ b/bt_helper.py
@@ -80,7 +80,16 @@ class BtDbusManager:
                 arg0 = "org.bluez.Device1",
                 path_keyword = "path")
         for adapter in self._get_objects_by_iface(ADAPTER_IFACE):
-            dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+            try:
+                dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+            except Exception as exc:
+                if exc.get_dbus_name() == 'org.bluez.Error.InProgress':
+                    logging.warning('Scan already in progress, restart it now')
+                    dbus.Interface(adapter, ADAPTER_IFACE).StopDiscovery()
+                    dbus.Interface(adapter, ADAPTER_IFACE).StartDiscovery()
+                else:
+                    logging.error('Unable to start scanning - {}'
+                                  .format(exc.get_dbus_message())
         GObject.timeout_add(10000, self._scan_timeout)
         self._main_loop.run()
 


### PR DESCRIPTION
Ask the interface to restart discovery if it's already in scanning.
- Not a very good solution, it might also fail to stop / start discovery in that if, and making runaway exceptions.
