### PR TITLE
Add exception handler to connect action.

### DIFF
--- a/bt_helper.py
+++ b/bt_helper.py
@@ -121,14 +121,10 @@ class BtDevice:
         self._bt_mgr.wait()
         try:
             self._if.Connect()
-        except Exception as exc:
+        except dbus.exceptions.DBusException as exc:
             logging.error('Failed to connect - {}'.format(exc.get_dbus_message()))
-        
-        self._if.Pair(
-            reply_handler=self._pair_ok, error_handler=self._pair_error)
-        self._bt_mgr.wait()
-        self._if.Connect()
-
+    
+    
     def unpair(self):
         #XXX: implement me
         pass

--- a/bt_helper.py
+++ b/bt_helper.py
@@ -119,6 +119,14 @@ class BtDevice:
         self._if.Pair(
             reply_handler=self._pair_ok, error_handler=self._pair_error)
         self._bt_mgr.wait()
+        try:
+            self._if.Connect()
+        except Exception as exc:
+            logging.error('Failed to connect - {}'.format(exc.get_dbus_message()))
+        
+        self._if.Pair(
+            reply_handler=self._pair_ok, error_handler=self._pair_error)
+        self._bt_mgr.wait()
         self._if.Connect()
 
     def unpair(self):


### PR DESCRIPTION
Add a try-except to the device connect action, to catch errors if it's not well-paired.

This closes #6. 
